### PR TITLE
on the first request, avoid posting body

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -307,15 +307,14 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		origReq.Header[k] = s
 	}
 
-	// We'll need the request body twice. In some cases we can use GetBody
-	// to obtain a fresh reader for the second request, which we do right
-	// before the RoundTrip(origReq) call. If GetBody is unavailable, read
-	// the body into a memory buffer and use it for both requests.
+
+	// Do not send the body on the first request
 	if req.Body != nil || req.GetBody == nil {
 		req.Body = nil
 		req.GetBody = nil
 		req.ContentLength = 0
 	}
+
 	// Make a request to get the 401 that contains the challenge.
 	challenge, resp, err := t.fetchChallenge(req)
 	if challenge == "" || err != nil {

--- a/digest.go
+++ b/digest.go
@@ -72,7 +72,6 @@
 package digest
 
 import (
-	"bytes"
 	"crypto/md5"
 	"crypto/rand"
 	"crypto/sha256"
@@ -312,13 +311,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// to obtain a fresh reader for the second request, which we do right
 	// before the RoundTrip(origReq) call. If GetBody is unavailable, read
 	// the body into a memory buffer and use it for both requests.
-	if req.Body != nil && req.GetBody == nil {
-		body, err := ioutil.ReadAll(req.Body)
-		if err != nil {
-			return nil, err
-		}
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-		origReq.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	if req.Body != nil || req.GetBody == nil {
+		req.Body = nil
+		req.GetBody = nil
+		req.ContentLength = 0
 	}
 	// Make a request to get the 401 that contains the challenge.
 	challenge, resp, err := t.fetchChallenge(req)


### PR DESCRIPTION
This is intended more as a point of discussion than a claim that this approach is truly the correct behavior –

I have modified `RoundTrip` to avoid posting the body of requests on the first request. I came across the same problem in the upstream as described in https://github.com/mongodb-forks/digest/pull/1. The RFC seems to imply that posting the entire body on the initial request is not necessary when not using integrity protection.