### PR TITLE
CLOUDP-237245: adding helper for using Http transport interface

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -124,7 +124,7 @@ func NewTransportWithHTTPTransport(username, password string, transport *http.Tr
 	return t
 }
 
-
+// NewTransportWithHTTPRoundTripper creates a new digest transport using the supplied http.RoundTripper interface.
 func NewTransportWithHTTPRoundTripper(username, password string, transport http.RoundTripper) *Transport {
 	t := &Transport{
 		Username:  username,

--- a/digest.go
+++ b/digest.go
@@ -124,6 +124,16 @@ func NewTransportWithHTTPTransport(username, password string, transport *http.Tr
 	return t
 }
 
+
+func NewTransportWithHTTPRoundTripper(username, password string, transport http.RoundTripper) *Transport {
+	t := &Transport{
+		Username:  username,
+		Password:  password,
+		Transport: transport,
+	}
+	return t
+}
+
 type challenge struct {
 	Realm     string
 	Domain    string


### PR DESCRIPTION
**Context**

Current digest library uses `transport *http.Transport` as interface for creating new transport. 
However the generic http interface relies on `http.RoundTripper` pointer interface.

**Change**

Adding helper to support interoperability with libraries that confirm with `http.RoundTripper`. 

**Notes**

Left previous version of the method to not cause unneeded breaking changes. Both use cases are correct and valid.