### PR TITLE
Add CODEOWNERS for apix-devtools team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Maintained by the MongoDB Atlas CLI team
+*       @mongodb-forks/apix-2


### PR DESCRIPTION
Adds `.github/CODEOWNERS` to auto-request the apix-devtools team for review on all PRs.

Part of CLOUDP-362273 — the last remaining repo without code owners configured.